### PR TITLE
Switch to mmap implementaion from nix package

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uio"
-version = "0.1.1"
+version = "1.0.0"
 authors = ["Gerd Zellweger <mail@gerdzellweger.com>"]
 description = "Helper library for writing linux user-space drivers with UIO."
 homepage = "https://github.com/gz/rust-uio"
@@ -12,5 +12,5 @@ license = "MIT"
 
 [dependencies]
 fs2 = "0.4.3"
-mmap = "0.1.*"
-libc = "0.1.*"
+nix = "0.11.0"
+libc = "0.2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,11 +1,9 @@
 extern crate fs2;
 extern crate libc;
-extern crate mmap;
+extern crate nix;
 
 #[cfg(target_os = "linux")]
 mod linux;
 
 #[cfg(target_os = "linux")]
 pub use linux::*;
-
-pub use mmap::MemoryMap;


### PR DESCRIPTION
The mmap crate is unmantained and depends on libc that has broken mmap call on
32-bit ARM. Switch to nix::sys::mman::mmap interface.

This change breaks API compatibility, since we return `*mut c_void` instead of
`mmap::MemoryMap`.