### PR TITLE
update nix, use `?` operator instead of `try!`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,5 +11,5 @@ license = "MIT"
 
 [dependencies]
 fs2 = "0.4.3"
-nix = "0.11.0"
+nix = "0.26.2"
 libc = "0.2"


### PR DESCRIPTION
I encountered some issues on aarch64 musl requiring to bump nix to a newer version. Also replace `try!` with `?`