### PR TITLE
Fix /dev/uio* file locking

### DIFF
--- a/src/linux.rs
+++ b/src/linux.rs
@@ -44,6 +44,14 @@ pub struct UioDevice {
     devfile: File,
 }
 
+impl Drop for UioDevice {
+    fn drop(&mut self) {
+        self.devfile
+            .unlock()
+            .expect("Failed to release lock on /dev/uio* device");
+    }
+}
+
 impl UioDevice {
     /// Creates a new UIO device for Linux.
     ///


### PR DESCRIPTION
This fixes the main issue raised in #8, and adds some API for handling the locked case without blocking.