### PR TITLE
Fix UioDevice get_ methods

### DIFF
--- a/src/linux.rs
+++ b/src/linux.rs
@@ -157,6 +157,16 @@ impl UioDevice {
         }
     }
 
+    /// UIO device number (e.g. 0 for /dev/uio0)
+    pub fn get_num(&self) -> usize {
+        self.uio_num
+    }
+
+    /// Path to UIO device file (e.g. "/dev/uio0")
+    pub fn get_dev_path(&self) -> impl AsRef<std::path::Path> {
+        format!("/dev/uio{}", self.uio_num)
+    }
+
     /// The name of the UIO device.
     pub fn get_name(&self) -> Result<String, UioError> {
         let filename = format!("/sys/class/uio/uio{}/name", self.uio_num);


### PR DESCRIPTION
UioDevice::get_mapping_info() is the most significant change, as explained in the commit.

get_num() & get_dev_path() are some useful extra methods for debugging/logging in downstream crates.