### PR TITLE
Fix/error trait

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uio"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["Gerd Zellweger <mail@gerdzellweger.com>"]
 description = "Helper library for writing linux user-space drivers with UIO."
 repository = "https://github.com/gz/rust-uio"

--- a/src/linux.rs
+++ b/src/linux.rs
@@ -38,6 +38,20 @@ impl From<nix::Error> for UioError {
     }
 }
 
+impl std::fmt::Display for UioError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            UioError::Address => write!(f, "Invalid address"),
+            UioError::Size => write!(f, "Invalid size"),
+            UioError::Io(e) => write!(f, "IO error: {}", e),
+            UioError::Map(e) => write!(f, "Map error: {}", e),
+            UioError::Parse => write!(f, "Parse error"),
+        }
+    }
+}
+
+impl std::error::Error for UioError {}
+
 pub struct UioDevice {
     uio_num: usize,
     //path: &'static str,

--- a/src/linux.rs
+++ b/src/linux.rs
@@ -361,7 +361,7 @@ mod tests {
 
     #[test]
     fn open() {
-        let res = ::linux::UioDevice::try_new(0);
+        let res = crate::linux::UioDevice::try_new(0);
         match res {
             Err(e) => {
                 panic!("Can not open device /dev/uio0: {}", e);
@@ -372,7 +372,7 @@ mod tests {
 
     #[test]
     fn print_info() {
-        let res = ::linux::UioDevice::try_new(0).unwrap();
+        let res = crate::linux::UioDevice::try_new(0).unwrap();
         let name = res.get_name().expect("Can't get name");
         let version = res.get_version().expect("Can't get version");
         let event_count = res.get_event_count().expect("Can't get event count");
@@ -383,7 +383,7 @@ mod tests {
 
     #[test]
     fn map() {
-        let res = ::linux::UioDevice::try_new(0).unwrap();
+        let res = crate::linux::UioDevice::try_new(0).unwrap();
         let bars = res.map_resource(5);
         match bars {
             Err(e) => {
@@ -395,7 +395,7 @@ mod tests {
 
     #[test]
     fn bar_info() {
-        let mut res = ::linux::UioDevice::try_new(0).unwrap();
+        let mut res = crate::linux::UioDevice::try_new(0).unwrap();
         let bars = res.get_resource_info();
         match bars {
             Err(e) => {


### PR DESCRIPTION
implements the `std::error:Error` trait, as requested in #7 

@gz or another maintainer would have to make a tag to match the version number.