### PR TITLE
Fix/nix 0.30.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uio"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Gerd Zellweger <mail@gerdzellweger.com>"]
 description = "Helper library for writing linux user-space drivers with UIO."
 repository = "https://github.com/gz/rust-uio"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,5 +11,5 @@ license = "MIT"
 
 [dependencies]
 fs2 = "0.4.3"
-nix = "0.26.2"
+nix = { version = "0.30.1", features = ["mman"] }
 libc = "0.2"

--- a/src/linux.rs
+++ b/src/linux.rs
@@ -7,7 +7,6 @@ use std::io;
 use std::io::prelude::*;
 use std::num::{NonZeroUsize, ParseIntError};
 use std::os::fd;
-use std::os::unix::prelude::AsRawFd;
 
 const PAGESIZE: usize = 4096;
 
@@ -122,7 +121,6 @@ impl UioDevice {
             .open(filename.to_string())?;
         let metadata = fs::metadata(filename.clone())?;
         let length = NonZeroUsize::new(metadata.len() as usize).ok_or(UioError::Size)?;
-        let fd = f.as_raw_fd();
 
         let res = unsafe {
             nix::sys::mman::mmap(
@@ -130,12 +128,12 @@ impl UioDevice {
                 length,
                 ProtFlags::PROT_READ | ProtFlags::PROT_WRITE,
                 MapFlags::MAP_SHARED,
-                fd,
+                f,
                 0 as libc::off_t,
             )
         };
         match res {
-            Ok(m) => Ok(m),
+            Ok(m) => Ok(m.as_ptr()),
             Err(e) => Err(UioError::from(e)),
         }
     }
@@ -288,7 +286,6 @@ impl UioDevice {
     ///  * mapping: The given index of the mapping (i.e., 1 for /sys/class/uio/uioX/maps/map1)
     pub fn map_mapping(&self, mapping: usize) -> Result<*mut libc::c_void, UioError> {
         let offset = mapping * PAGESIZE;
-        let fd = self.as_raw_fd();
         let map_size = self.map_size(mapping)?;
         let map_size = NonZeroUsize::new(map_size).ok_or(UioError::Size)?;
 
@@ -298,12 +295,12 @@ impl UioDevice {
                 map_size,
                 ProtFlags::PROT_READ | ProtFlags::PROT_WRITE,
                 MapFlags::MAP_SHARED,
-                fd,
+                self,
                 offset as libc::off_t,
             )
         };
         match res {
-            Ok(m) => Ok(m),
+            Ok(m) => Ok(m.as_ptr()),
             Err(e) => Err(UioError::from(e)),
         }
     }
@@ -333,6 +330,12 @@ impl UioDevice {
 impl fd::AsRawFd for UioDevice {
     fn as_raw_fd(&self) -> fd::RawFd {
         self.devfile.as_raw_fd()
+    }
+}
+
+impl fd::AsFd for UioDevice {
+    fn as_fd(&self) -> fd::BorrowedFd<'_> {
+        self.devfile.as_fd()
     }
 }
 


### PR DESCRIPTION
updated nix to 0.30.1

this change probably requires a bit of testing, though by bumping the version, users of uio could remain on 0.4.0 until they have confidence this version works for them.

I imagine that #13 would be merged before this PR. note that this will create a merge conflict due to the version update. I or someone else can rebase or otherwise resolve the conflict after #13 is merged.

@gz or another maintainer would need to make a tag after this is merged to match the version number.