### PR TITLE
src/linux: added derive debug and clone for mapping info struct

### DIFF
--- a/src/linux.rs
+++ b/src/linux.rs
@@ -356,6 +356,7 @@ impl fd::AsFd for UioDevice {
 
 /// All information about one of a UioDevice's Mapping
 /// This is a dump of everything contained in `/sys/class/uio/uio{n}/maps/map*/*`
+#[derive(Debug, Clone)]
 pub struct MappingInfo {
     /// Index of the Mapping
     ///


### PR DESCRIPTION
added `#[derive(Debug, Clone)]` for `MappingInfo`.