### PR TITLE
cargo: bump version to 0.5.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uio"
-version = "0.5.1"
+version = "0.5.2"
 authors = ["Gerd Zellweger <mail@gerdzellweger.com>"]
 description = "Helper library for writing linux user-space drivers with UIO."
 repository = "https://github.com/gz/rust-uio"


### PR DESCRIPTION
new release so the changes from #17 can be published.