### PR TITLE
cargo: relax the nix dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,5 +12,5 @@ edition = "2021"
 
 [dependencies]
 fs2 = "0.4.3"
-nix = { version = "0.30.1", features = ["mman"] }
+nix = { version = "0.30", features = ["mman"] }
 libc = "0.2"


### PR DESCRIPTION
allow all nix 0.30.x versions to ease dependency resolving for projects using this uio library. not allowing nix 0.31.x at this moment because compatibility has not been tested and is not guaranteed by the 0.x.y version series.