### PR TITLE
chore: bump version to 0.6.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uio"
-version = "0.5.2"
+version = "0.6.0"
 authors = ["Gerd Zellweger <mail@gerdzellweger.com>"]
 description = "Helper library for writing linux user-space drivers with UIO."
 repository = "https://github.com/gz/rust-uio"


### PR DESCRIPTION
whenever everything else is ready (including #27 and #28 ), we can bump the version as proposed in https://github.com/gz/rust-uio/pull/23#pullrequestreview-4094419337