### PR TITLE
Fix/cargo registry token

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,10 +9,15 @@ jobs:
   publish:
     runs-on: ubuntu-24.04
     environment: release
+    permissions:
+      id-token: write
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Trusted publishing crates.io
+        uses: rust-lang/crates-io-auth-action@bbd81622f20ce9e2dd9622e3218b975523e45bbe # v1.0.4
+        id: auth
       - name: Install Nix
         uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31.10.6
         with:
@@ -35,3 +40,5 @@ jobs:
 
       - name: Cargo publish
         run: nix develop -c -- cargo publish
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,5 +20,18 @@ jobs:
             experimental-features = nix-command flakes
             accept-flake-config = true
 
+      - name: Verify tag version matches Cargo.toml version
+        run: |
+          TAG_VERSION="${{ steps.get_tag.outputs.tag }}"
+          CLEAN_TAG_VERSION="${TAG_VERSION#v}"
+          CARGO_VERSION=$(nix develop -c -- toml get Cargo.toml package.version)
+          echo "Tag version: $CLEAN_TAG_VERSION"
+          echo "Cargo.toml version: $CARGO_VERSION"
+          if [ "$CLEAN_TAG_VERSION" != "$CARGO_VERSION" ]; then
+            echo "Tag version does not match Cargo.toml version"
+            exit 1
+          fi
+        shell: bash
+
       - name: Cargo publish
         run: nix develop -c -- cargo publish

--- a/flake.nix
+++ b/flake.nix
@@ -46,6 +46,7 @@
                 rustToolchain
                 pkgs.nixd
                 pkgs.nil
+                pkgs.toml-cli
               ];
             };
           };


### PR DESCRIPTION
follow up changes on #28 including tag/version check and cargo variables.
1. added cargo version / tag match check
2. added `CARGO_REGISTRY_TOKEN` env variable using crates.io trusted publishing

@gz , I did not see any secrets in the settings of this repo. will you add a cargo registry token?